### PR TITLE
Add static typing for paymenr method tokenization

### DIFF
--- a/saleor/plugins/webhook/tests/test_payment_method_initialize_tokenization.py
+++ b/saleor/plugins/webhook/tests/test_payment_method_initialize_tokenization.py
@@ -358,11 +358,12 @@ def test_payment_method_initialize_tokenization_missing_required_id(
     channel_USD,
 ):
     # given
-    expected_error_msg = "Missing payment method `id` in response."
-    mock_request.return_value = {
+    return_value = {
         "result": result,
         "data": None,
     }
+    mock_request.return_value = return_value
+    expected_error_msg = f"Missing value for field: id. Input: {return_value}."
 
     plugin = webhook_plugin()
 

--- a/saleor/plugins/webhook/tests/test_payment_method_process_tokenization.py
+++ b/saleor/plugins/webhook/tests/test_payment_method_process_tokenization.py
@@ -367,14 +367,14 @@ def test_payment_method_process_tokenization_missing_required_id(
     webhook_plugin,
     payment_method_process_tokenization_app,
     channel_USD,
-    app,
 ):
     # given
-    expected_error_msg = "Missing payment method `id` in response."
-    mock_request.return_value = {
+    return_value = {
         "result": result,
         "data": None,
     }
+    mock_request.return_value = return_value
+    expected_error_msg = f"Missing value for field: id. Input: {return_value}."
 
     plugin = webhook_plugin()
 

--- a/saleor/plugins/webhook/tests/test_stored_payment_method_request_delete.py
+++ b/saleor/plugins/webhook/tests/test_stored_payment_method_request_delete.py
@@ -356,10 +356,7 @@ def test_stored_payment_method_request_delete_missing_result_in_response_from_we
     assert not EventDelivery.objects.exists()
 
     assert response.result == StoredPaymentMethodRequestDeleteResult.FAILED_TO_DELETE
-    assert (
-        response.error
-        == "Incorrect value ({}) for field: result. Error: Field required."
-    )
+    assert response.error == "Missing value for field: result. Input: {}."
 
 
 @mock.patch("saleor.webhook.transport.synchronous.transport.cache.delete")

--- a/saleor/webhook/response_schemas/payment.py
+++ b/saleor/webhook/response_schemas/payment.py
@@ -6,15 +6,20 @@ from pydantic import (
     BaseModel,
     Field,
     JsonValue,
+    ValidationInfo,
     field_validator,
+    model_validator,
 )
 
+from ...app.models import App
 from ...graphql.core.utils import str_to_enum
 from ...payment import TokenizedPaymentFlow
 from ...payment.interface import (
     PaymentGatewayInitializeTokenizationResult,
+    PaymentMethodTokenizationResult,
     StoredPaymentMethodRequestDeleteResult,
 )
+from ..transport.utils import to_payment_app_id
 from .utils.annotations import DefaultIfNone, EnumByName, OnErrorDefault, OnErrorSkip
 from .utils.validators import lower_values
 
@@ -137,9 +142,95 @@ class PaymentGatewayInitializeTokenizationSessionSchema(BaseModel):
     data: Annotated[
         DefaultIfNone[JsonValue],
         Field(
+            default=None,
             description="A data required to finalize the initialization.",
+        ),
+    ]
+    error: Annotated[
+        str | None,
+        Field(
+            description="Error message that will be passed to the frontend.",
             default=None,
         ),
+    ]
+
+
+def clean_id(payment_method_id: str, info: ValidationInfo) -> str:
+    app: App | None = info.context.get("app", None) if info.context else None
+    if not app:
+        raise RuntimeError("Missing app in context")
+    return to_payment_app_id(app, payment_method_id)
+
+
+def clean_result(result: str):
+    return PaymentMethodTokenizationResult[result]
+
+
+class PaymentMethodTokenizationSuccessSchema(BaseModel):
+    id: Annotated[str, Field(description="ID of the payment method.")]
+    result: Annotated[  # type: ignore[name-defined]
+        Literal[
+            PaymentMethodTokenizationResult.SUCCESSFULLY_TOKENIZED.name,
+            PaymentMethodTokenizationResult.ADDITIONAL_ACTION_REQUIRED.name,
+        ],
+        Field(
+            description="Result of the payment method tokenization.",
+        ),
+        AfterValidator(clean_result),
+    ]
+    data: Annotated[
+        DefaultIfNone[JsonValue],
+        Field(
+            description="A data passes to the client.",
+            default=None,
+        ),
+    ]
+
+    @model_validator(mode="after")
+    def clean_id(self, info: ValidationInfo):
+        payment_method_id = self.id
+        self.id = clean_id(payment_method_id, info)
+        return self
+
+
+class PaymentMethodTokenizationPendingSchema(BaseModel):
+    id: Annotated[
+        str | None, Field(description="ID of the payment method.", default=None)
+    ]
+    result: Annotated[  # type: ignore[name-defined]
+        Literal[PaymentMethodTokenizationResult.PENDING.name],
+        Field(
+            description="Result of the payment method tokenization.",
+        ),
+        AfterValidator(clean_result),
+    ]
+    data: Annotated[
+        DefaultIfNone[JsonValue],
+        Field(
+            description="A data passes to the client.",
+            default=None,
+        ),
+    ]
+
+    @model_validator(mode="after")
+    def clean_id(self, info: ValidationInfo):
+        payment_method_id = self.id
+        if payment_method_id is None:
+            return self
+        self.id = clean_id(payment_method_id, info)
+        return self
+
+
+class PaymentMethodTokenizationFailedSchema(BaseModel):
+    result: Annotated[  # type: ignore[name-defined]
+        Literal[
+            PaymentMethodTokenizationResult.FAILED_TO_TOKENIZE.name,
+            PaymentMethodTokenizationResult.FAILED_TO_DELIVER.name,
+        ],
+        Field(
+            description="Result of the payment method tokenization.",
+        ),
+        AfterValidator(clean_result),
     ]
     error: Annotated[
         str | None,

--- a/saleor/webhook/response_schemas/utils/helpers.py
+++ b/saleor/webhook/response_schemas/utils/helpers.py
@@ -10,7 +10,12 @@ def parse_validation_error(error: ValidationError) -> str:
         loc_data = error_data["loc"]
         if loc_data:
             field = str(loc_data[0])
-        error_msg.append(
-            f"Incorrect value ({error_data['input']}) for field: {field}. Error: {error_data['msg']}."
-        )
+        if error_data.get("type") == "missing":
+            error_msg.append(
+                f"Missing value for field: {field}. Input: {error_data['input']}."
+            )
+        else:
+            error_msg.append(
+                f"Incorrect value ({error_data['input']}) for field: {field}. Error: {error_data['msg']}."
+            )
     return "\n\n".join(error_msg)

--- a/saleor/webhook/tests/response_schemas/test_helpers.py
+++ b/saleor/webhook/tests/response_schemas/test_helpers.py
@@ -3,7 +3,7 @@ from pydantic import BaseModel, ValidationError
 from ...response_schemas.utils.helpers import parse_validation_error
 
 
-class TestSchema(BaseModel):
+class ExampleSchema(BaseModel):
     field1: int
     field2: str
 
@@ -14,7 +14,7 @@ def test_parse_validation_error_single_error():
 
     # when
     try:
-        TestSchema.model_validate(invalid_data)
+        ExampleSchema.model_validate(invalid_data)
     except ValidationError as error:
         error_msg = parse_validation_error(error)
 
@@ -30,7 +30,7 @@ def test_parse_validation_error_multiple_errors():
 
     # when
     try:
-        TestSchema.model_validate(invalid_data)
+        ExampleSchema.model_validate(invalid_data)
     except ValidationError as error:
         error_msg = parse_validation_error(error)
 
@@ -39,3 +39,17 @@ def test_parse_validation_error_multiple_errors():
         f"Incorrect value ({invalid_data['field1']}) for field: field1. Error: Input should be a valid integer, unable to parse string as an integer.\n\n"
         f"Incorrect value ({invalid_data['field2']}) for field: field2. Error: Input should be a valid string."
     )
+
+
+def test_parse_validation_error_missing_field_value():
+    # given
+    invalid_data = {"field1": 1232}
+
+    # when
+    try:
+        ExampleSchema.model_validate(invalid_data)
+    except ValidationError as error:
+        error_msg = parse_validation_error(error)
+
+    # then
+    assert error_msg == f"Missing value for field: field2. Input: {invalid_data}."

--- a/saleor/webhook/tests/response_schemas/test_payment.py
+++ b/saleor/webhook/tests/response_schemas/test_payment.py
@@ -5,16 +5,21 @@ from pydantic import ValidationError
 
 from ....payment.interface import (
     PaymentGatewayInitializeTokenizationResult,
+    PaymentMethodTokenizationResult,
     StoredPaymentMethodRequestDeleteResult,
 )
 from ...response_schemas.payment import (
     CreditCardInfoSchema,
     ListStoredPaymentMethodsSchema,
     PaymentGatewayInitializeTokenizationSessionSchema,
+    PaymentMethodTokenizationFailedSchema,
+    PaymentMethodTokenizationPendingSchema,
+    PaymentMethodTokenizationSuccessSchema,
     StoredPaymentMethodDeleteRequestedSchema,
     StoredPaymentMethodSchema,
 )
 from ...response_schemas.utils.annotations import logger as annotations_logger
+from ...transport.utils import to_payment_app_id
 
 
 @pytest.mark.parametrize(
@@ -598,7 +603,7 @@ def test_stored_payment_method_delete_requested_schema_invalid(data, invalid_fie
         },
     ],
 )
-def test_payment_gateway_initizlize_tokenization_session_schema_valid(data):
+def test_payment_gateway_initialize_tokenization_session_schema_valid(data):
     # when
     schema = PaymentGatewayInitializeTokenizationSessionSchema.model_validate(data)
 
@@ -653,7 +658,7 @@ def test_payment_gateway_initizlize_tokenization_session_schema_valid(data):
         ),
     ],
 )
-def test_payment_gateway_initizlize_tokenization_session_schema_invalid(
+def test_payment_gateway_initialize_tokenization_session_schema_invalid(
     data, invalid_field
 ):
     # when
@@ -663,3 +668,249 @@ def test_payment_gateway_initizlize_tokenization_session_schema_invalid(
     # then
     assert len(exc_info.value.errors()) == 1
     assert exc_info.value.errors()[0]["loc"][0] == invalid_field
+
+
+@pytest.mark.parametrize(
+    "data",
+    [
+        # SUCCESSFULLY_TOKENIZED with not data and no error
+        {
+            "id": "123",
+            "result": PaymentMethodTokenizationResult.SUCCESSFULLY_TOKENIZED.name,
+        },
+        # ADDITIONAL_ACTION_REQUIRED with data
+        {
+            "id": "456",
+            "result": PaymentMethodTokenizationResult.ADDITIONAL_ACTION_REQUIRED.name,
+            "data": {"action": "verify"},
+        },
+    ],
+)
+def test_payment_method_tokenization_schema_valid(data, app):
+    # when
+    schema = PaymentMethodTokenizationSuccessSchema.model_validate(
+        data, context={"app": app}
+    )
+
+    # then
+    assert schema.result == PaymentMethodTokenizationResult[data["result"]]
+    assert schema.data == data.get("data")
+    assert schema.id == to_payment_app_id(app, data["id"])
+
+
+def test_payment_method_tokenization_schema_valid_extra_data_in_input(app):
+    # given
+    data = {
+        "id": "123",
+        "result": PaymentMethodTokenizationResult.SUCCESSFULLY_TOKENIZED.name,
+        "error": "extra error value",
+        "data": {"key": "value"},
+    }
+
+    # when
+    schema = PaymentMethodTokenizationSuccessSchema.model_validate(
+        data, context={"app": app}
+    )
+
+    # then
+    assert schema.result == PaymentMethodTokenizationResult[data["result"]]
+    assert schema.data == data.get("data")
+    assert schema.id == to_payment_app_id(app, data["id"])
+
+
+@pytest.mark.parametrize(
+    ("data", "expected_error_field"),
+    [
+        # Missing `id` field
+        (
+            {
+                "result": PaymentMethodTokenizationResult.SUCCESSFULLY_TOKENIZED.name,
+                "data": {"key": "value"},
+            },
+            "id",
+        ),
+        # Missing `result` field
+        (
+            {
+                "id": "123",
+                "data": {"key": "value"},
+                "error": None,
+            },
+            "result",
+        ),
+        # Invalid `result` value
+        (
+            {
+                "id": "123",
+                "result": "INVALID_RESULT",
+            },
+            "result",
+        ),
+        # `id` field with wrong type
+        (
+            {
+                "id": 123,
+                "result": PaymentMethodTokenizationResult.SUCCESSFULLY_TOKENIZED.name,
+                "data": {"key": "value"},
+                "error": None,
+            },
+            "id",
+        ),
+    ],
+)
+def test_payment_method_tokenization_schema_invalid(data, expected_error_field, app):
+    # when
+    with pytest.raises(ValidationError) as exc_info:
+        PaymentMethodTokenizationSuccessSchema.model_validate(
+            data, context={"app": app}
+        )
+
+    # then
+    assert len(exc_info.value.errors()) == 1
+    assert exc_info.value.errors()[0]["loc"][0] == expected_error_field
+
+
+@pytest.mark.parametrize(
+    "data",
+    [
+        # All fields provided
+        {
+            "id": "123",
+            "result": PaymentMethodTokenizationResult.PENDING.name,
+            "data": {"status": "pending"},
+        },
+        # `id` is None
+        {
+            "id": None,
+            "result": PaymentMethodTokenizationResult.PENDING.name,
+            "data": {"status": "pending"},
+        },
+        # No data provided
+        {
+            "id": "456",
+            "result": PaymentMethodTokenizationResult.PENDING.name,
+        },
+    ],
+)
+def test_payment_method_tokenization_pending_schema_valid(data, app):
+    # when
+    schema = PaymentMethodTokenizationPendingSchema.model_validate(
+        data, context={"app": app}
+    )
+
+    # then
+    assert schema.result == PaymentMethodTokenizationResult.PENDING
+    assert schema.data == data.get("data", None)
+    assert schema.id == (to_payment_app_id(app, data["id"]) if data["id"] else None)
+
+
+@pytest.mark.parametrize(
+    ("data", "expected_error_field"),
+    [
+        # Missing `result` field
+        (
+            {
+                "id": "123",
+                "data": {"status": "pending"},
+            },
+            "result",
+        ),
+        # Invalid `result` value
+        (
+            {
+                "id": "123",
+                "result": "INVALID_RESULT",
+                "data": {"status": "pending"},
+            },
+            "result",
+        ),
+        # `id` field with wrong type
+        (
+            {
+                "id": 123,
+                "result": PaymentMethodTokenizationResult.PENDING.name,
+                "data": {"status": "pending"},
+            },
+            "id",
+        ),
+    ],
+)
+def test_payment_method_tokenization_pending_schema_invalid(data, expected_error_field):
+    # when
+    with pytest.raises(ValidationError) as exc_info:
+        PaymentMethodTokenizationPendingSchema.model_validate(data)
+
+    # then
+    assert len(exc_info.value.errors()) == 1
+    assert exc_info.value.errors()[0]["loc"][0] == expected_error_field
+
+
+@pytest.mark.parametrize(
+    "data",
+    [
+        # `FAILED_TO_TOKENIZE`` with error message
+        {
+            "result": PaymentMethodTokenizationResult.FAILED_TO_TOKENIZE.name,
+            "error": "Tokenization failed.",
+        },
+        # `FAILED_TO_DELIVER`` with error message
+        {
+            "result": PaymentMethodTokenizationResult.FAILED_TO_DELIVER.name,
+            "error": "Tokenization failed.",
+        },
+        # `FAILED_TO_TOKENIZE` without error message
+        {
+            "result": PaymentMethodTokenizationResult.FAILED_TO_TOKENIZE.name,
+            "error": None,
+        },
+        # `FAILED_TO_DELIVER` without error message
+        {
+            "result": PaymentMethodTokenizationResult.FAILED_TO_DELIVER.name,
+        },
+    ],
+)
+def test_payment_method_tokenization_failed_schema_valid(data):
+    # when
+    schema = PaymentMethodTokenizationFailedSchema.model_validate(data)
+
+    # then
+    assert schema.result == PaymentMethodTokenizationResult[data["result"]]
+    assert schema.error == data.get("error")
+
+
+@pytest.mark.parametrize(
+    ("data", "expected_error_field"),
+    [
+        # Missing `result` field
+        (
+            {
+                "error": "Tokenization failed due to invalid input.",
+            },
+            "result",
+        ),
+        # Invalid `result` value
+        (
+            {
+                "result": "INVALID_RESULT",
+                "error": "Invalid result value.",
+            },
+            "result",
+        ),
+        # `error` field with wrong type
+        (
+            {
+                "result": PaymentMethodTokenizationResult.FAILED_TO_TOKENIZE.name,
+                "error": 123,  # Should be a string or None
+            },
+            "error",
+        ),
+    ],
+)
+def test_payment_method_tokenization_failed_schema_invalid(data, expected_error_field):
+    # when
+    with pytest.raises(ValidationError) as exc_info:
+        PaymentMethodTokenizationFailedSchema.model_validate(data)
+
+    # then
+    assert len(exc_info.value.errors()) == 1
+    assert exc_info.value.errors()[0]["loc"][0] == expected_error_field


### PR DESCRIPTION
Recreated from original PR: https://github.com/saleor/saleor/pull/17708

Introduce static typing for following webhooks:
- `PAYMENT_METHOD_INITIALIZE_TOKENIZATION_SESSION`
- `PAYMENT_METHOD_PROCESS_TOKENIZATION_SESSION`

<!-- Please mention all relevant issue numbers. -->
<!-- GitHub issue number is required for external contributions. -->

# Impact

- [ ] New migrations
- [ ] New/Updated API fields or mutations
- [ ] Deprecated API fields or mutations
- [ ] Removed API types, fields, or mutations

# Docs

<!-- Docs are stored in a separate repository...